### PR TITLE
ReduceMean divides by the whole size of the matrix

### DIFF
--- a/src/AleaTK/Library.cs
+++ b/src/AleaTK/Library.cs
@@ -598,12 +598,17 @@ namespace AleaTK
 
         public static Expr<T> ReduceMean<T>(Expr<T> a, bool keepDims, params int[] reductionIndices)
         {
-            return ReduceSum(a, keepDims, reductionIndices) / (a.Shape.Length.AsScalar<T>());
+            if (reductionIndices == null || reductionIndices.Length == 0)
+            {
+                reductionIndices = Enumerable.Range(0, a.Shape.Rank).ToArray();
+            }
+            var numberOfElements = reductionIndices.Select(index => a.Shape[index]).Aggregate((x, y) => x * y);
+            return ReduceSum(a, keepDims, reductionIndices) / (numberOfElements.AsScalar<T>());
         }
 
         public static Expr<T> ReduceMean<T>(Expr<T> a, params int[] reductionIndices)
         {
-            return ReduceSum(a, reductionIndices) / (a.Shape.Length.AsScalar<T>());
+            return ReduceMean(a, false, reductionIndices);
         }
 
         public static Expr<T> RandomUniform<T>(Shape shape = null, ulong? seed = null, ulong offset = 0UL,

--- a/src/AleaTKUtil/Common.cs
+++ b/src/AleaTKUtil/Common.cs
@@ -228,6 +228,34 @@ namespace AleaTKUtil
             return Enumerable.Range(0, numElements).Select(_ => (float)(Random.NextDouble() * (maxValue - minValue) + minValue)).ToArray();
         }
 
+        public static float[] ReduceToColumnMeans(float [,]array)
+        {
+            var output = new float[array.GetLength(1)];
+            for (var column = 0; column < output.Length; ++column)
+            {
+                for (var row = 0; row < array.GetLength(0); ++row)
+                {
+                    output[column] += array[row, column];
+                }
+                output[column] /= array.GetLength(0);
+            }
+            return output;
+        }
+
+        public static float[] ReduceToRowMeans(float[,] array)
+        {
+            var output = new float[array.GetLength(0)];
+            for (var row = 0; row < output.Length; ++row)
+            {
+                for (var column = 0; column < array.GetLength(1); ++column)
+                {
+                    output[row] += array[row, column];
+                }
+                output[row] /= array.GetLength(1);
+            }
+            return output;
+        }
+
         public static void Dump<T>(T[] array)
         {
             for (var i = 0; i < array.Length; ++i)

--- a/tests/AleaTKTest/TensorComputing.cs
+++ b/tests/AleaTKTest/TensorComputing.cs
@@ -506,6 +506,38 @@ namespace AleaTKTest
         }
 
         [Test]
+        public static void Reduce2DMeanByRowGPU()
+        {
+            var ctx = gpu;
+     
+            var input = RandomNormal<float>(Shape.Create(1000, 10), 0UL);
+            var inputTensor = ctx.Eval(input);
+            var inputArray = inputTensor.ToArray2D();
+            var expectedOutput = ReduceToColumnMeans(inputArray);
+
+            var outputTensor = ctx.Eval(ReduceMean(input, 0));
+            var actualOutput = outputTensor.ToArray();
+
+            Assert.That(actualOutput, Is.EqualTo(expectedOutput).AsCollection.Within(1e-5));
+        }
+
+        [Test]
+        public static void Reduce2DMeanByColumnGPU()
+        {
+            var ctx = gpu;
+
+            var input = RandomNormal<float>(Shape.Create(10, 1000), 0UL);
+            var inputTensor = ctx.Eval(input);
+            var inputArray = inputTensor.ToArray2D();
+            var expectedOutput = ReduceToRowMeans(inputArray);
+
+            var outputTensor = ctx.Eval(ReduceMean(input, 1));
+            var actualOutput = outputTensor.ToArray();
+
+            Assert.That(actualOutput, Is.EqualTo(expectedOutput).AsCollection.Within(1e-5));
+        }
+
+        [Test]
         public static void AssignUniformRandomCpu()
         {
             var ctx = cpu;


### PR DESCRIPTION
During implementation of different layers I noticed that ReduceMean divides by the full size of the matrix instead of only the reduced index sizes as expected by different implementations implemented R, [Numpy](https://docs.scipy.org/doc/numpy/reference/generated/numpy.mean.html), [Matlab](https://ch.mathworks.com/help/matlab/ref/mean.html), etc. 

Please have a look at the tests as an example. 

Please feel free to adjust the coding style, optimize the implementation of the PR, mainly it was for a topic to discussion.

Thanks for the time and attention