### PR TITLE
Shaping output tensor the same way as the output array

### DIFF
--- a/src/AleaTK/Library.cs
+++ b/src/AleaTK/Library.cs
@@ -429,7 +429,7 @@ namespace AleaTK
             var l2 = tensor.Layout.Shape.Skip(2).Aggregate(ScalarOps.Mul);
             var array = new T[l0, l1, l2];
             var cpuTensor = array.AsTensor();
-            context.Copy(cpuTensor, tensor).Wait();
+            context.Copy(cpuTensor, tensor.Reshape(l0, l1, l2)).Wait();
             return array;
         }
 


### PR DESCRIPTION
During debugging I realized that the output variable shape is shaped by aggregating the dimension higher then 3. But the tensor isn't shaped before the copying it causing a crash on transforming a 4D tensor to 3D array.
This one line fix would be intended to fix this small glitch.  